### PR TITLE
Added license information

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -15,6 +15,7 @@
     <description lang="pt">Emissões em directo (Rádio e TV) e On-Demand da RTP Play (rádio e tv).</description>
     <disclaimer lang="pt">Plugin independente e de código aberto não produzido pela rtp</disclaimer>
     <disclaimer lang="en">Independent and opensource plugin not endorsed by RTP</disclaimer>
+    <license>GNU GENERAL PUBLIC LICENSE. Version 2, June 1991</license>
     <forum>http://forum.xbmc.org/showthread.php?tid=154645</forum>
     <source>https://github.com/enen92/plugin.video.RTPPlay-XBMC</source>
     <website>http://www.rtp.pt/play</website>


### PR DESCRIPTION
Needed to automatically fill the links on http://kodi.wiki and http://addons.kodi.tv/ sites.