### PR TITLE
Adição dos programas da rtpplay e pequenas alterações

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.rtpplay" name="RTP Play" version="5.0.0" provider-name="enen92, guipenedo">
+<addon id="plugin.video.rtpplay" name="RTP Play" version="5.0.1" provider-name="enen92, guipenedo">
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>
         <import addon="script.module.routing" version="0.2.0"/>

--- a/addon.xml
+++ b/addon.xml
@@ -4,7 +4,7 @@
         <import addon="xbmc.python" version="2.25.0"/>
         <import addon="script.module.routing" version="0.2.0"/>
         <import addon="script.module.requests" version="2.12.4"/>
-        <import addon="script.module.inputstreamhelper" version="0.3.5"/>
+        <import addon="script.module.inputstreamhelper" version="0.4.1"/>
         <import addon="script.module.beautifulsoup4" version="4.6.2"/>
     </requires>
     <extension point="xbmc.python.pluginsource" library="main.py">

--- a/addon.xml
+++ b/addon.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.rtpplay" name="RTP Play" version="5.0.0" provider-name="enen92">
+<addon id="plugin.video.rtpplay" name="RTP Play" version="5.0.0" provider-name="enen92, guipenedo">
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>
         <import addon="script.module.routing" version="0.2.0"/>
         <import addon="script.module.requests" version="2.12.4"/>
-        <import addon="script.module.inputstreamhelper" version="0.3.3"/>
+        <import addon="script.module.inputstreamhelper" version="0.3.5"/>
+        <import addon="script.module.beautifulsoup4" version="4.6.2"/>
     </requires>
     <extension point="xbmc.python.pluginsource" library="main.py">
         <provides>video</provides>
@@ -20,8 +21,9 @@
         <email>enen92@kodi.tv</email>
         <source>https://github.com/enen92/plugin.video.rtpplay</source>
         <news>
-            - Fix thumbs and EPG
-            - Python3 support for Matrix
+            - Added progress percentage to live tv
+            - Added programs from RTPPlay
+            - Added searching
         </news>
         <disclaimer lang="en_GB">The plugin is unnoficial and not endorsed by RTP. Expect it to break. </disclaimer>
         <assets>

--- a/resources/language/resource.language.pt_pt/strings.po
+++ b/resources/language/resource.language.pt_pt/strings.po
@@ -30,7 +30,7 @@ msgstr "Não foi possível obter o url da stream. O plugin precisa de uma atuali
 
 msgctxt "#32003"
 msgid "Debug"
-msgstr ""
+msgstr "Depuração"
 
 msgctxt "#32004"
 msgid "Live TV"

--- a/resources/language/resource.language.pt_pt/strings.po
+++ b/resources/language/resource.language.pt_pt/strings.po
@@ -22,11 +22,11 @@ msgstr ""
 
 msgctxt "#32001"
 msgid "Could not complete request. The plugin needs an update."
-msgstr ""
+msgstr "Não foi possível completar o pedido. O plugin precisa de uma atualização."
 
 msgctxt "#32002"
 msgid "Could not grab stream url. The plugin needs an update."
-msgstr ""
+msgstr "Não foi possível obter o url da stream. O plugin precisa de uma atualização."
 
 msgctxt "#32003"
 msgid "Debug"
@@ -34,24 +34,24 @@ msgstr ""
 
 msgctxt "#32004"
 msgid "Live TV"
-msgstr ""
+msgstr "Em direto"
 
 msgctxt "#32005"
 msgid "Programs"
-msgstr ""
+msgstr "Programas"
 
 msgctxt "#32006"
 msgid "Search"
-msgstr ""
+msgstr "Pesquisar"
 
 msgctxt "#32007"
 msgid "Search query"
-msgstr ""
+msgstr "Texto para pesquisar"
 
 msgctxt "#32008"
 msgid "Results for"
-msgstr ""
+msgstr "Resultados para"
 
 msgctxt "#32009"
 msgid "Page"
-msgstr ""
+msgstr "Página"

--- a/resources/lib/plugin.py
+++ b/resources/lib/plugin.py
@@ -283,7 +283,9 @@ def programs_episodes():
         url = a.get('href')
         img = ""
         if a.find('script') != None:
-            img = re.search(r'\'(.+?)\'', a.find('script').text).group(1)
+            match = re.search(r'\'(.+?)\'', a.find('script').text)
+            if len(match.groups()) > 0:
+                img = match.group(1)
         metas = a.find_next_sibling('i').find_all('meta')
         description = metas[1].get('content')
         ep = metas[0].get('content')

--- a/resources/lib/plugin.py
+++ b/resources/lib/plugin.py
@@ -18,8 +18,10 @@ from resources.lib.channels import RTP_CHANNELS, HEADERS
 
 if kodiutils.PY3:
     from urllib.parse import urlencode
+    from html.parser import HTMLParser
 else:
     from urllib import urlencode
+    from HTMLParser import HTMLParser
 
 
 ADDON = xbmcaddon.Addon()
@@ -193,7 +195,8 @@ def programs():
 
     i = 0
     for name in match:
-        name = BeautifulSoup(kodiutils.compat_py23str(name), "html.parser").text
+        name = HTMLParser().unescape(kodiutils.compat_py23str(name))
+        name = name.encode('utf8', 'replace')
         liz = ListItem(name)
         addDirectoryItem(handle=plugin.handle, listitem=liz, isFolder=True, url=plugin.url_for(programs_category, name=name, id=i, page=1))
         i = i + 1
@@ -310,7 +313,15 @@ def programs_episodes():
 
     newpage = str(int(page) + 1)
     nextpage = ListItem("[B]{}[/B] - {} {} >>>".format(title, kodiutils.get_string(32009), newpage))
-    addDirectoryItem(handle=plugin.handle, listitem=nextpage, isFolder=True, url=plugin.url_for(programs_episodes, title=title, ep=ep, img=img, url=url, page=newpage))
+    addDirectoryItem(handle=plugin.handle, 
+        listitem=nextpage, 
+        isFolder=True, 
+        url=plugin.url_for(programs_episodes, 
+            title=kodiutils.compat_py23str(title), 
+            ep=kodiutils.compat_py23str(ep),
+            img=kodiutils.compat_py23str(img), 
+            url=kodiutils.compat_py23str(url), 
+            page=newpage))
 
     endOfDirectory(plugin.handle)
 


### PR DESCRIPTION
Antes de mais nada parabéns pelo projeto. Encontrei-o ontem quando estava a tentar assistir a [programas que estão no rtpplay](https://www.rtp.pt/play/programas) no kodi. Apesar de este addon só ter livetv, até como o próprio nome era "rtpplay" resolvi adicionar esta parte do rtpplay diretamente, em vez de criar um novo addon.

O que fiz foi:

- O menu inicial tem agora 3 opções: "Em direto", "Programas" e "Pesquisar"
- O "Em direto" corresponde à versão anterior do addon - tem a livetv - com a pequena adição da percentagem do progresso do programa
- A opção "Programas" carrega a lista de categorias que está no site
- Carregando numa dessas categorias são apresentadas várias páginas com o conteúdo dessa categoria, com descrições de cada programa, data e thumbnail
- Carregando num programa, é aberta a lista de episódios do mesmo, sendo que carregando num o reproduz
- O menu "Pesquisar" devolve os resultados para a pesquisa nos programas

Se houver alguma coisa que não está de acordo com o teu estilo ou preferência é só avisar.