### PR TITLE
Correção do url do vídeo

### DIFF
--- a/resources/lib/plugin.py
+++ b/resources/lib/plugin.py
@@ -334,11 +334,7 @@ def programs_play():
 
     try:
         req = requests.get("https://www.rtp.pt" + url, headers=HEADERS).text
-        
-        soup = BeautifulSoup(req, 'html.parser')
-    
-        script = soup.find_all('script')[-1].text
-        stream = re.search(r'file: "(.*)"', script).group(1)
+        stream = "https://streaming-ondemand.rtp.pt" + re.search(r'"https://streaming-ondemand.rtp.pt(.*)"', req).group(1)
     except:
         raise_notification()
 


### PR DESCRIPTION
Algures nas últimas 2 semanas o html do site da RTPPlay mudou. Enquanto que antes tínhamos "file: (endereço ficheiro)", agora temos "file : (endereço ficheiro)". Tendo em conta que esta é a unica key com um espaço antes dos :, desconfio que a alteração tenha sido propositada.
Esta nova versão do plugin.py procura diretamente o video pelo seu url, por isso a menos que agora decidam mudar o subdominio so para partir o addon, pelo menos esta parte vai continuar a funcionar.