### PR TITLE
Fixes for on demand url retrieval

### DIFF
--- a/resources/lib/plugin.py
+++ b/resources/lib/plugin.py
@@ -340,8 +340,8 @@ def programs_play():
 
     try:
         req = requests.get("https://www.rtp.pt" + url, headers=HEADERS)
-        req.encoding = "utf-8"
-        stream = re.search(r'"https://(.+?)ondemand.rtp.pt(.*)"', req.text)
+        req.encoding = "latin-1"
+        stream = re.search(r'"https://(.+?)ondemand.rtp.pt(.*?)"', req.text)
         stream = "https://" + stream.group(1) + "ondemand.rtp.pt" + stream.group(2)
     except:
         raise_notification()


### PR DESCRIPTION
Apparently some programs (and only some) have a download link on rtpplay's website. Changing the regex fixes kodi attempting to play, for instance:
`https://cdn-ondemand.rtp.pt/nas2.share/wavrss/at3/2002/6267580_322817-2002210923.mp3" rel="nofollow" title="Fa&ccedil;a o download do ficheiro"><i class="fal fa-arrow-to-bottom`
(https://www.rtp.pt/play/p6179/e457543/minuto-verde)

and limit the result to the first occurrence of ".

Hopefully fixes #22 