### PR TITLE
Updated find_stream_url()

### DIFF
--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -134,7 +134,7 @@ def kodi_json_request(params):
 
 def find_stream_url(html):
     url = ''
-
+    # Needles para procura da informação de stream no HaysTackML
     needle = [  "hls : atob( decodeURIComponent(",
                 "hls : ",
                 '.mp3',
@@ -181,8 +181,6 @@ def find_stream_url(html):
         url = url.replace("/master.m3u8",".mp4")
 
     return url
-
-    raise ValueError
 
 
 def convertVttSrt(fileContents):

--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -134,7 +134,6 @@ def kodi_json_request(params):
 
 def find_stream_url(html):
     url = ''
-    i = 0
 
     needle = [  "hls : atob( decodeURIComponent(",
                 "hls : ",


### PR DESCRIPTION
Updated **find_stream_url** for the new RTP Play storage and supply mechanism through web browser.

Tested with:
» Programas / Episódios: https://www.rtp.pt/play/p3909/e308024/4play
» Documentários: https://www.rtp.pt/play/p8632/kubrick-na-voz-de-kubrick
» #estudoemcasa: https://www.rtp.pt/play/estudoemcasa/p7776/portugues-1-ano
» Palco: https://www.rtp.pt/play/palco/p7732/electrico
» Rádio Podcast: https://www.rtp.pt/play/p8695/flawless-radio

PS: Last night RTP Play stopped working on PC browsers (400 and 403 errors on the previous working stream endpoints) so add-on isn't working... Not sure if all this work was for nothing...